### PR TITLE
Fix issue of bad suggestions when query matches start of existing word

### DIFF
--- a/createTrie-test.js
+++ b/createTrie-test.js
@@ -111,6 +111,16 @@ test("should include suggestions that match the query", () => {
   expect(completion.suggest("list")).toEqual(["list"]);
 });
 
+test("should not include suggestions that do not match the query", () => {
+  const completion = createTrie();
+
+  completion.insert("list");
+  completion.insert("listen");
+
+  expect(completion.suggest("listening")).toEqual([]);
+  expect(completion.suggest("lost")).toEqual([]);
+});
+
 test("should be able to populate given a dictionary list of words", () => {
   const dictionary = [
     "ape",

--- a/createTrie.js
+++ b/createTrie.js
@@ -37,8 +37,8 @@ function createTrie() {
     const endOfQueryNode = nodePath[nodePath.length - 1];
     const startingSuggestions = [];
 
-    // the trie contains no path match for the query, only rootNode
-    if (nodePath.length === 1) return [];
+    // the trie contains no path match for the query
+    if (nodePath.length === 0) return [];
 
     // the query itself matches a word in the trie
     if (endOfQueryNode.getIsCompleteString()) {
@@ -99,12 +99,15 @@ function createTrie() {
 
   // private methods
   function getNodePath(query) {
-    let nodePath = [rootNode];
+    let nodePath = [];
     let parentNode = rootNode;
 
     for (const letter of query.split("")) {
       const childNode = parentNode.getChildren()[letter];
-      if (!childNode) return nodePath;
+
+      // a node does not exist for some letter in the query
+      if (!childNode) return [];
+
       nodePath.push(childNode);
       parentNode = childNode;
     }


### PR DESCRIPTION
The private function getNodePath had a subtle bug in that it would still
return a list of nodes even if that list did not have a one-to-one
mapping of nodes to letters in the query. This resulted in suggestions
being populated with words if the query had *at least* one letter prefix
that matched the word, whereas it should only match if the query has
*exactly* a prefix of a word (meaning that queries longer than existing
words should also return an empty suggestions list).

Fixes #1